### PR TITLE
Add setting to always launch ShellCheck with the workspace root as cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
 					"default": {},
 					"description": "Mathing files and directories are being ignored by shellcheck. Glob patterns are interpreted relative to the workspace's root folder."
 				},
+				"shellcheck.useWorkspaceRootAsCwd": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to use the workspace root directory as the current working directory when launching ShellCheck."
+				},
 				"shellcheck.useWSL": {
 					"type": "boolean",
 					"default": false,


### PR DESCRIPTION
Setting is `useWorkspaceRootAsCwd` (boolean). The rationale for this is that ShellCheck source directives may be specified as relative to the root of the workspace, which is more compatible with the behaviour of many other editors when used in conjunction with ShellCheck.

For example, Vim might be launched from the root of the workspace, and ShellCheck will be able to follow the source directives consistently by being anchored from the root path under which it was launched. This in turn means the editor doesn't have to always launch ShellCheck under the directory of the file to be linted, and that source directives do not have to be always relative to the location of each individual file.

The setting is disabled by default, in which case the existing behaviour is retained. This is to set ShellCheck's current working directory to that of the file being linted, unless the file has not yet been saved, in which case we fallback to the workspace root directory.