### PR TITLE
chore(dependabot): ignore @types/node and @types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@types/node"
+      - dependency-name: "@types/vscode"


### PR DESCRIPTION
We don't want to update VSCode or Node version to keep the compatibility.