### PR TITLE
fix: not loading `shellcheck` from `PATH` when the bundled is not available

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -154,7 +154,7 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
         }
 
         // Fallback to default shellcheck path
-        if (!executablePath) {
+        if (!isBundled) {
             executablePath = 'shellcheck';
         }
 


### PR DESCRIPTION
When bundled binaries are not available.

Fixes: #244
