### PR TITLE
fix: loading bundled binary on Windows `ia32` arch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,13 +8,5 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
-[Makefile]
-indent_size = 4
-indent_style = tab
-
-[package.json]
-indent_size = 4
-indent_style = tab
-
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,6 @@
     "env": {
         "es6": true,
         "node": true,
-        "mocha": true,
+        "mocha": true
     }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - ">=13"
+          - ">=11"
       - dependency-name: "@types/vscode"
         versions:
           - ">=1.39"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,58 +1,61 @@
 name: ci
 
 on:
-    push:
-        branches: [master]
-    pull_request:
-        branches: [master]
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-    test:
-        strategy:
-            matrix:
-                os: [ubuntu-latest, macos-latest]
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        vscode-version: [1.38.1, stable]
 
-        runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-        steps:
-            - uses: actions/checkout@v2
-            - name: Use Node.js 12
-              uses: actions/setup-node@v2
-              with:
-                  node-version: 12
-            - run: yarn install
-            - name: Test
-              uses: GabrielBB/xvfb-action@v1
-              with:
-                  run: yarn test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: yarn install
+      - name: Test with VS Code ${{ matrix.vscode-version }}
+        uses: GabrielBB/xvfb-action@v1
+        env:
+          VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
+        with:
+          run: yarn test
 
-    release:
-        needs: test
+  release:
+    needs: test
 
-        runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  token: ${{ secrets.GH_TOKEN_SEMANTIC_RELEASE }}
-            - name: Use Node.js 12
-              uses: actions/setup-node@v2
-              with:
-                  node-version: 12
-            - run: yarn install
-            - run: yarn run release
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
-            - if: github.event_name == 'pull_request'
-              name: Create extension vsix for pull request
-              run: |
-                pr_number=$([[ "${GITHUB_REF}" =~ ^refs/pull/(.*)/merge$ ]] && echo ${BASH_REMATCH[1]})
-                yarn version --prerelease --preid "pr-${pr_number}" --no-git-tag-version
-                yarn run package
-            - if: github.event_name == 'pull_request'
-              name: Archive the extension vsix for pull request
-              uses: actions/upload-artifact@v2
-              with:
-                name: extension-vsix
-                path: "*.vsix"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN_SEMANTIC_RELEASE }}
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: yarn install
+      - run: yarn run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+      - if: github.event_name == 'pull_request'
+        name: Create extension vsix for pull request
+        run: |
+          pr_number=$([[ "${GITHUB_REF}" =~ ^refs/pull/(.*)/merge$ ]] && echo ${BASH_REMATCH[1]})
+          yarn version --prerelease --preid "pr-${pr_number}" --no-git-tag-version
+          yarn run package
+      - if: github.event_name == 'pull_request'
+        name: Archive the extension vsix for pull request
+        uses: actions/upload-artifact@v2
+        with:
+          name: extension-vsix
+          path: "*.vsix"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,6 +49,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--new-window",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/out/test/suite"
             ],
@@ -65,25 +66,26 @@
             }
         },
         {
-			"name": "Launch Tests (Webpack)",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/dist/test/suite"
-			],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			// outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "npm: pretest",
-			"env": {
-				"DEBUGTELEMETRY": "1",
-				"NODE_DEBUG": ""
-			}
-		},
+            "name": "Launch Tests (Webpack)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--new-window",
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/dist/test/suite"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            // outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "preLaunchTask": "npm: pretest",
+            "env": {
+                "DEBUGTELEMETRY": "1",
+                "NODE_DEBUG": ""
+            }
+        },
     ]
 }

--- a/.vscode/spell.json
+++ b/.vscode/spell.json
@@ -1,29 +1,29 @@
 {
-  "language": "en",
-  "ignoreWordsList": [
-    "json",
-    "shellcheck"
-  ],
-  "mistakeTypeToStatus": {
-    "Passive voice": "Hint",
-    "Spelling": "Error",
-    "Complex Expression": "Disable",
-    "Hidden Verbs": "Information",
-    "Hyphen Required": "Disable",
-    "Redundant Expression": "Disable",
-    "Did you mean...": "Disable",
-    "Repeated Word": "Warning",
-    "Missing apostrophe": "Warning",
-    "Cliches": "Disable",
-    "Missing Word": "Disable",
-    "Make I uppercase": "Warning"
-  },
-  "languageIDs": [
-    "markdown",
-    "plaintext"
-  ],
-  "ignoreRegExp": [
-    "/\\(.*\\.(jpg|jpeg|png|md|gif|JPG|JPEG|PNG|MD|GIF)\\)/g",
-    "/((http|https|ftp|git)\\S*)/g"
-  ]
+    "language": "en",
+    "ignoreWordsList": [
+        "json",
+        "shellcheck"
+    ],
+    "mistakeTypeToStatus": {
+        "Passive voice": "Hint",
+        "Spelling": "Error",
+        "Complex Expression": "Disable",
+        "Hidden Verbs": "Information",
+        "Hyphen Required": "Disable",
+        "Redundant Expression": "Disable",
+        "Did you mean...": "Disable",
+        "Repeated Word": "Warning",
+        "Missing apostrophe": "Warning",
+        "Cliches": "Disable",
+        "Missing Word": "Disable",
+        "Make I uppercase": "Warning"
+    },
+    "languageIDs": [
+        "markdown",
+        "plaintext"
+    ],
+    "ignoreRegExp": [
+        "/\\(.*\\.(jpg|jpeg|png|md|gif|JPG|JPEG|PNG|MD|GIF)\\)/g",
+        "/((http|https|ftp|git)\\S*)/g"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,219 +1,219 @@
 {
-	"name": "shellcheck",
-	"displayName": "ShellCheck",
-	"description": "Integrates ShellCheck into VS Code, a linter for Shell scripts.",
-	"version": "0.15.1",
-	"publisher": "timonwong",
-	"author": "Timon Wong <timon86.wang@gmail.com> (https://github.com/timonwong)",
-	"contributors": [
-		"Felipe Santos (https://github.com/felipecrs)"
-	],
-	"license": "MIT",
-	"categories": [
-		"Linters",
-		"Programming Languages"
-	],
-	"keywords": [
-		"shell",
-		"shellscript",
-		"bash",
-		"linter",
-		"lint"
-	],
-	"homepage": "https://github.com/timonwong/vscode-shellcheck#readme",
-	"private": true,
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/timonwong/vscode-shellcheck.git"
-	},
-	"bugs": {
-		"url": "https://github.com/timonwong/vscode-shellcheck/issues"
-	},
-	"icon": "shellcheck.png",
-	"activationEvents": [
-		"onLanguage:shellscript"
-	],
-	"main": "./main",
-	"contributes": {
-		"commands": [
-			{
-				"command": "shellcheck.runLint",
-				"title": "ShellCheck: Run Linting"
-			}
-		],
-		"configuration": {
-			"title": "ShellCheck",
-			"type": "object",
-			"properties": {
-				"shellcheck.enable": {
-					"description": "Whether shellcheck is enabled or not.",
-					"type": "boolean",
-					"scope": "resource",
-					"default": true
-				},
-				"shellcheck.enableQuickFix": {
-					"description": "Whether to enable the \"Quick Fix\" feature.",
-					"type": "boolean",
-					"scope": "resource",
-					"default": true
-				},
-				"shellcheck.executablePath": {
-					"description": "Path to the shellcheck executable (builtin binaries will be used if empty).",
-					"examples": [
-						"shellcheck"
-					],
-					"type": "string",
-					"scope": "machine"
-				},
-				"shellcheck.run": {
-					"description": "Whether shellcheck is run on save or on type.",
-					"type": "string",
-					"enum": [
-						"onSave",
-						"onType",
-						"manual"
-					],
-					"scope": "resource",
-					"default": "onType"
-				},
-				"shellcheck.exclude": {
-					"description": "Exclude types of warnings, for example [\"1017\"].",
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"scope": "resource",
-					"default": []
-				},
-				"shellcheck.customArgs": {
-					"description": "Custom arguments to shellcheck.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"scope": "resource",
-					"default": []
-				},
-				"shellcheck.ignorePatterns": {
-					"markdownDescription": "Configure glob patterns for excluding files and folders by shellcheck. Glob patterns are interpreted relative to the workspace's root folder. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
-					"examples": [
-						{
-							"**/*.zsh": true,
-							"**/*.zsh*": true,
-							"**/.git/*.sh": true,
-							"**/folder/**/*.sh": true
-						}
-					],
-					"type": "object",
-					"scope": "resource",
-					"additionalProperties": {
-						"anyOf": [
-							{
-								"type": "boolean",
-								"description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
-							}
-						]
-					},
-					"default": {
-						"**/*.zsh": true,
-						"**/*.zshrc": true,
-						"**/zshrc": true,
-						"**/*.zprofile": true,
-						"**/zprofile": true,
-						"**/*.zlogin": true,
-						"**/zlogin": true,
-						"**/*.zlogout": true,
-						"**/zlogout": true,
-						"**/*.zshenv": true,
-						"**/zshenv": true,
-						"**/*.zsh-theme": true
-					}
-				},
-				"shellcheck.ignoreFileSchemes": {
-					"description": "Matching file schemes are being ignored by shellcheck.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					},
-					"scope": "application",
-					"default": [
-						"git",
-						"gitfs"
-					]
-				},
-				"shellcheck.useWorkspaceRootAsCwd": {
-					"description": "Whether to use the workspace root directory as the current working directory when launching ShellCheck.",
-					"type": "boolean",
-					"scope": "resource",
-					"default": false
-				},
-				"shellcheck.disableVersionCheck": {
-					"description": "Whether to disable shellcheck binary version check, which prompt for updating when outdated version found.",
-					"type": "boolean",
-					"scope": "application",
-					"default": false
-				}
-			}
-		}
-	},
-	"scripts": {
-		"prepare": "bindl",
-		"compile": "tsc -p ./",
-		"compile:dev": "tsc --watch -p ./",
-		"bundle": "webpack --mode none",
-		"bundle:prod": "webpack --mode production",
-		"bundle:dev": "webpack --watch --mode none",
-		"build": "yarn run bundle",
-		"build:prod": "yarn run bundle:prod",
-		"vscode:prepublish": "yarn run build:prod",
-		"package": "vsce package --yarn",
-		"publish": "vsce publish --yarn",
-		"lint": "tslint --project tsconfig.json -t verbose",
-		"lint:fix": "tslint --project tsconfig.json -t verbose --fix",
-		"pretest": "yarn run compile && yarn run build",
-		"test": "node ./out/test/runTest.js",
-		"posttest": "yarn run lint",
-		"release": "semantic-release"
-	},
-	"dependencies": {
-		"bl": "^4.0.3",
-		"execa": "^5.0.0",
-		"lodash": "^4.17.19",
-		"minimatch": "^3.0.4",
-		"semver": "^7.3.4"
-	},
-	"devDependencies": {
-		"@semantic-release/changelog": "^5.0.1",
-		"@semantic-release/git": "^9.0.0",
-		"@types/glob": "^7.1.4",
-		"@types/lodash": "^4.14.168",
-		"@types/minimatch": "^3.0.3",
-		"@types/mocha": "^5.2.5",
-		"@types/node": "^10.11.0",
-		"@types/semver": "^7.3.4",
-		"@types/vscode": "1.38.0",
-		"bindl": "^1.1.1",
-		"conventional-changelog-conventionalcommits": "^4.5.0",
-		"filemanager-webpack-plugin": "^2.0.5",
-		"glob": "^7.1.4",
-		"kind-of": "^6.0.3",
-		"mocha": "^5.2.0",
-		"semantic-release": "^17.4.4",
-		"semantic-release-vsce": "^3.1.3",
-		"terser-webpack-plugin": "^1.4.3",
-		"ts-loader": "^8.0.4",
-		"tslint": "^6.1.3",
-		"typescript": "^3.0.3",
-		"vscode-test": "^1.0.2",
-		"webpack": "^4.44.2",
-		"webpack-cli": "^3.3.6"
-	},
-	"engines": {
-		"vscode": "^1.38.0"
-	},
-	"__metadata": {
-		"id": "f95d8fff-f70a-4ae5-bb06-5c47ddbc8fc6",
-		"publisherDisplayName": "Timon Wong",
-		"publisherId": "04757770-dd50-443e-aae4-e1c7cf9c24f5"
-	}
+    "name": "shellcheck",
+    "displayName": "ShellCheck",
+    "description": "Integrates ShellCheck into VS Code, a linter for Shell scripts.",
+    "version": "0.15.1",
+    "publisher": "timonwong",
+    "author": "Timon Wong <timon86.wang@gmail.com> (https://github.com/timonwong)",
+    "contributors": [
+        "Felipe Santos (https://github.com/felipecrs)"
+    ],
+    "license": "MIT",
+    "categories": [
+        "Linters",
+        "Programming Languages"
+    ],
+    "keywords": [
+        "shell",
+        "shellscript",
+        "bash",
+        "linter",
+        "lint"
+    ],
+    "homepage": "https://github.com/timonwong/vscode-shellcheck#readme",
+    "private": true,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/timonwong/vscode-shellcheck.git"
+    },
+    "bugs": {
+        "url": "https://github.com/timonwong/vscode-shellcheck/issues"
+    },
+    "icon": "shellcheck.png",
+    "activationEvents": [
+        "onLanguage:shellscript"
+    ],
+    "main": "./main",
+    "contributes": {
+        "commands": [
+            {
+                "command": "shellcheck.runLint",
+                "title": "ShellCheck: Run Linting"
+            }
+        ],
+        "configuration": {
+            "title": "ShellCheck",
+            "type": "object",
+            "properties": {
+                "shellcheck.enable": {
+                    "description": "Whether shellcheck is enabled or not.",
+                    "type": "boolean",
+                    "scope": "resource",
+                    "default": true
+                },
+                "shellcheck.enableQuickFix": {
+                    "description": "Whether to enable the \"Quick Fix\" feature.",
+                    "type": "boolean",
+                    "scope": "resource",
+                    "default": true
+                },
+                "shellcheck.executablePath": {
+                    "description": "Path to the shellcheck executable (builtin binaries will be used if empty).",
+                    "examples": [
+                        "shellcheck"
+                    ],
+                    "type": "string",
+                    "scope": "machine"
+                },
+                "shellcheck.run": {
+                    "description": "Whether shellcheck is run on save or on type.",
+                    "type": "string",
+                    "enum": [
+                        "onSave",
+                        "onType",
+                        "manual"
+                    ],
+                    "scope": "resource",
+                    "default": "onType"
+                },
+                "shellcheck.exclude": {
+                    "description": "Exclude types of warnings, for example [\"1017\"].",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "scope": "resource",
+                    "default": []
+                },
+                "shellcheck.customArgs": {
+                    "description": "Custom arguments to shellcheck.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "scope": "resource",
+                    "default": []
+                },
+                "shellcheck.ignorePatterns": {
+                    "markdownDescription": "Configure glob patterns for excluding files and folders by shellcheck. Glob patterns are interpreted relative to the workspace's root folder. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
+                    "examples": [
+                        {
+                            "**/*.zsh": true,
+                            "**/*.zsh*": true,
+                            "**/.git/*.sh": true,
+                            "**/folder/**/*.sh": true
+                        }
+                    ],
+                    "type": "object",
+                    "scope": "resource",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "type": "boolean",
+                                "description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
+                            }
+                        ]
+                    },
+                    "default": {
+                        "**/*.zsh": true,
+                        "**/*.zshrc": true,
+                        "**/zshrc": true,
+                        "**/*.zprofile": true,
+                        "**/zprofile": true,
+                        "**/*.zlogin": true,
+                        "**/zlogin": true,
+                        "**/*.zlogout": true,
+                        "**/zlogout": true,
+                        "**/*.zshenv": true,
+                        "**/zshenv": true,
+                        "**/*.zsh-theme": true
+                    }
+                },
+                "shellcheck.ignoreFileSchemes": {
+                    "description": "Matching file schemes are being ignored by shellcheck.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "scope": "application",
+                    "default": [
+                        "git",
+                        "gitfs"
+                    ]
+                },
+                "shellcheck.useWorkspaceRootAsCwd": {
+                    "description": "Whether to use the workspace root directory as the current working directory when launching ShellCheck.",
+                    "type": "boolean",
+                    "scope": "resource",
+                    "default": false
+                },
+                "shellcheck.disableVersionCheck": {
+                    "description": "Whether to disable shellcheck binary version check, which prompt for updating when outdated version found.",
+                    "type": "boolean",
+                    "scope": "application",
+                    "default": false
+                }
+            }
+        }
+    },
+    "scripts": {
+        "prepare": "bindl",
+        "compile": "tsc -p ./",
+        "compile:dev": "tsc --watch -p ./",
+        "bundle": "webpack --mode none",
+        "bundle:prod": "webpack --mode production",
+        "bundle:dev": "webpack --watch --mode none",
+        "build": "yarn run bundle",
+        "build:prod": "yarn run bundle:prod",
+        "vscode:prepublish": "yarn run build:prod",
+        "package": "vsce package --yarn",
+        "publish": "vsce publish --yarn",
+        "lint": "tslint --project tsconfig.json -t verbose",
+        "lint:fix": "tslint --project tsconfig.json -t verbose --fix",
+        "pretest": "yarn run compile && yarn run build",
+        "test": "node ./out/test/runTest.js",
+        "posttest": "yarn run lint",
+        "release": "semantic-release"
+    },
+    "dependencies": {
+        "bl": "^4.0.3",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4"
+    },
+    "devDependencies": {
+        "@semantic-release/changelog": "^5.0.1",
+        "@semantic-release/git": "^9.0.0",
+        "@types/glob": "^7.1.4",
+        "@types/lodash": "^4.14.168",
+        "@types/minimatch": "^3.0.3",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.11.0",
+        "@types/semver": "^7.3.4",
+        "@types/vscode": "1.38.0",
+        "bindl": "^2.0.0",
+        "conventional-changelog-conventionalcommits": "^4.5.0",
+        "filemanager-webpack-plugin": "^2.0.5",
+        "glob": "^7.1.4",
+        "kind-of": "^6.0.3",
+        "mocha": "^5.2.0",
+        "semantic-release": "^17.4.4",
+        "semantic-release-vsce": "^3.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "ts-loader": "^8.0.4",
+        "tslint": "^6.1.3",
+        "typescript": "^3.0.3",
+        "vscode-test": "^1.0.2",
+        "webpack": "^4.44.2",
+        "webpack-cli": "^3.3.6"
+    },
+    "engines": {
+        "vscode": "^1.38.0"
+    },
+    "__metadata": {
+        "id": "f95d8fff-f70a-4ae5-bb06-5c47ddbc8fc6",
+        "publisherDisplayName": "Timon Wong",
+        "publisherId": "04757770-dd50-443e-aae4-e1c7cf9c24f5"
+    }
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -149,7 +149,7 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
             let suffix = '';
             let osarch = process.arch;
             if (process.platform === 'win32') {
-                if (process.arch === 'x64') {
+                if (process.arch === 'x64' || process.arch === 'ia32') {
                     osarch = 'x32';
                 }
                 suffix = '.exe';

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -17,8 +17,11 @@ async function main() {
             extensionDevelopmentPath,
             extensionTestsPath,
             launchArgs: [
+                '--new-window',
                 '--disable-extensions',
             ],
+            // Use VSCODE_TEST_VERSION if set
+            ...(process.env.VSCODE_TEST_VERSION ? { version: process.env.VSCODE_TEST_VERSION } : {})
         });
     } catch (err) {
         console.error('Failed to run tests');

--- a/test/suite/fix-all.test.ts
+++ b/test/suite/fix-all.test.ts
@@ -5,7 +5,6 @@ import { sleep } from './utils';
 
 suite('Fix all', () => {
     test('Extension should fix ssues automatically on demand', async () => {
-        <vscode.Extension<any>>vscode.extensions.getExtension('timonwong.shellcheck');
         const document = await vscode.workspace.openTextDocument({
             content: '#!/bin/bash\necho $SHELL\necho $SHELL\neval `uname -r`',
             language: 'shellscript',

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,16 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@felipecrs/decompress-tarxz@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@felipecrs/decompress-tarxz/-/decompress-tarxz-4.0.0.tgz#08a7106787f09c846e073fcb8acf04225b8d3bf6"
+  integrity sha512-dOzgzpLXYd2wbqAzK+YVX7U9Y1Wm5rJLTQ52zfBDyL3uwRVY5vtzyH9wntAgGa7Z29m5F2CehBdDBdCvC9WMSg==
+  dependencies:
+    decompress-tar "^4.1.0"
+    file-type "^16.5.2"
+    is-stream "^2.0.0"
+    lzma-native "^8.0.1"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -293,29 +303,29 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^9.2.0":
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-9.2.0.tgz#46bbfe6a85bfd2987e69216955fcd04df7d025bb"
-  integrity sha512-c4A1Xm0At+ypvBfEETREu519wLncJYQXvY+dBGg/V5YA51eg5EwdDsPPfcOMG0cuXscqRvsIgIySTmTJUdcTNA==
+"@octokit/openapi-types@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-9.3.0.tgz#160347858d727527901c6aae7f7d5c2414cc1f2e"
+  integrity sha512-oz60hhL+mDsiOWhEwrj5aWXTOMVtQgcvP+sRzX4C3cH7WOK9QSAoEtjWh0HdOf6V3qpdgAmUMxnQPluzDWR7Fw==
 
 "@octokit/plugin-paginate-rest@^2.6.2":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz#f469cb4a908792fb44679c5973d8bba820c88b0f"
-  integrity sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.15.0.tgz#9c956c3710b2bd786eb3814eaf5a2b17392c150d"
+  integrity sha512-/vjcb0w6ggVRtsb8OJBcRR9oEm+fpdo8RJk45khaWw/W0c8rlB2TLCLyZt/knmC17NkX7T9XdyQeEY7OHLSV1g==
   dependencies:
-    "@octokit/types" "^6.18.0"
+    "@octokit/types" "^6.23.0"
 
 "@octokit/plugin-request-log@^1.0.2":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
-"@octokit/plugin-rest-endpoint-methods@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.5.2.tgz#c8bdb3065a9725e30802295f10a31b3ff434830c"
-  integrity sha512-1ArooY7AYQdUd2zyqWLFHQ6gver9PvZSiuM+EPAsDplv1Y6u8zHl6yZ7yGIgaf7xvWupwUkJS2WttGYyb1P0DQ==
+"@octokit/plugin-rest-endpoint-methods@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.6.0.tgz#c28833b88d0f07bf94093405d02d43d73c7de99b"
+  integrity sha512-2G7lIPwjG9XnTlNhe/TRnpI8yS9K2l68W4RP/ki3wqw2+sVeTK8hItPxkqEI30VeH0UwnzpuksMU/yHxiVVctw==
   dependencies:
-    "@octokit/types" "^6.22.0"
+    "@octokit/types" "^6.23.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
@@ -340,21 +350,21 @@
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^18.0.0":
-  version "18.7.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.7.2.tgz#8239b5acd40fccb3f5d074e7a4386980f3770821"
-  integrity sha512-TAedgLqNRS+rdGqS9v00sqBeS6IgyLSoqqCDu6pmoadAB7xSjFHShxzaXUAbxxJjyHtb7mencRGzgH4W/V6Myg==
+  version "18.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.8.0.tgz#ba24f7ba554f015a7ae2b7cc2aecef5386ddfea5"
+  integrity sha512-lsuNRhgzGnLMn/NmQTNCit/6jplFWiTUlPXhqN0zCMLwf2/9pseHzsnTW+Cjlp4bLMEJJNPa5JOzSLbSCOahKw==
   dependencies:
     "@octokit/core" "^3.5.0"
     "@octokit/plugin-paginate-rest" "^2.6.2"
     "@octokit/plugin-request-log" "^1.0.2"
-    "@octokit/plugin-rest-endpoint-methods" "5.5.2"
+    "@octokit/plugin-rest-endpoint-methods" "5.6.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.18.0", "@octokit/types@^6.22.0":
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.22.0.tgz#389bade20955c919241b6ffb9dd33f6e0cf1cc6c"
-  integrity sha512-Y8GR0BJHQDpO09qw/ZQpN+DXrFzCWaE0pvK4frDm3zJ+h99AktsFfBoDazbCtHxiL8d0jD8xRH4BeynlKLeChg==
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.23.0":
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.23.0.tgz#b39f242b20036e89fa8f34f7962b4e9b7ff8f65b"
+  integrity sha512-eG3clC31GSS7K3oBK6C6o7wyXPrkP+mu++eus8CSZdpRytJ5PNszYxudOQ0spWZQ3S9KAtoTG6v1WK5prJcJrA==
   dependencies:
-    "@octokit/openapi-types" "^9.2.0"
+    "@octokit/openapi-types" "^9.3.0"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
@@ -466,6 +476,11 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
+
+"@tokenizer/token@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
+  integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -1135,11 +1150,12 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bindl@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/bindl/-/bindl-1.1.1.tgz#4ac588ba263e6f24d993ac666f18b95f6ec7381a"
-  integrity sha512-2tnX4yaKfQKyCooiDMHn12GYqx5jGfT5NUf1Q9N8buf6Ivtb452RCR5K/8uFDsNFtsM/PGfBzJFk39NOU+8SRQ==
+bindl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bindl/-/bindl-2.0.0.tgz#c0af6f3fdd2a235084298c95d12a7630f6174b83"
+  integrity sha512-G+ct//6RQsqCqDya/pA5FrjNt1FotQslnO9xh1cwTvJrBq/5LqejNVilKl21sDTqWh2CtpdBtZpX28klTpeLmQ==
   dependencies:
+    "@felipecrs/decompress-tarxz" "^4.0.0"
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1.17.0"
     "@oclif/plugin-help" "^3.2.0"
@@ -1148,13 +1164,11 @@ bindl@^1.1.1:
     decompress-tar "^4.1.1"
     decompress-tarbz2 "^4.1.1"
     decompress-targz "^4.1.1"
-    decompress-tarxz "^3.0.0"
     decompress-unzip "^4.0.1"
     download "^8.0.0"
     listr "^0.14.3"
     pkginfo "^0.4.1"
     shelljs "^0.8.4"
-    tslib "^2.0.1"
 
 bl@^1.0.0:
   version "1.2.3"
@@ -2152,13 +2166,6 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.6:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -2217,16 +2224,6 @@ decompress-targz@^4.0.0, decompress-targz@^4.1.1:
     decompress-tar "^4.1.1"
     file-type "^5.2.0"
     is-stream "^1.1.0"
-
-decompress-tarxz@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-tarxz/-/decompress-tarxz-3.0.0.tgz#28217766a75e57c2923623782b065441155640cd"
-  integrity sha512-/85049bKZOmkVXrFz9Zf90DMBPYuXGGAMOQaytNgMGiB7u4iIJKLUaEXRiLBvugtknmYcP1Zv6KQWEYWshTblg==
-  dependencies:
-    decompress-tar "^4.1.0"
-    file-type "^12.3.0"
-    is-stream "^2.0.0"
-    lzma-native "^4.0.5"
 
 decompress-unzip@^4.0.1:
   version "4.0.1"
@@ -2337,11 +2334,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -2829,10 +2821,14 @@ file-type@^11.1.0:
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-11.1.0.tgz#93780f3fed98b599755d846b99a1617a2ad063b8"
   integrity sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g==
 
-file-type@^12.3.0:
-  version "12.4.2"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-12.4.2.tgz#a344ea5664a1d01447ee7fb1b635f72feb6169d9"
-  integrity sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==
+file-type@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.2.tgz#e6626f7a253af2ecf499f31995f0e849226825a8"
+  integrity sha512-lnHRZj2USLF3v4C5ZY7/vQQeoTVA1YV9TtD6UUCr9z5Cd0uyutqxPBJxkXzM6lufPNuSfefq/yFmnSPz0C3wNw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "6.1.3"
+    token-types "^3.0.0"
 
 file-type@^3.8.0:
   version "3.9.0"
@@ -3061,13 +3057,6 @@ fs-extra@^9.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
-
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
 
 fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   version "2.1.0"
@@ -3601,13 +3590,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@^0.4.4:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
 iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
@@ -3615,7 +3597,7 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -3625,7 +3607,7 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
-ignore-walk@^3.0.1, ignore-walk@^3.0.3:
+ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
   integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
@@ -4605,15 +4587,14 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lzma-native@^4.0.5:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lzma-native/-/lzma-native-4.0.6.tgz#1b26670d844660b41f8114dce6618719a89f307e"
-  integrity sha512-1kiSs/KAcAuh9vyyd00ATXZFfrg6W8UCBqH1RKlWg/tBP5aQez6HYOY+SihmsZfpy0RVDioW5SLI76dZ3Mq5Rw==
+lzma-native@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/lzma-native/-/lzma-native-8.0.1.tgz#8569e2f88de461a9a2469ac9d8183637c387d682"
+  integrity sha512-Ryr9X3yDVZhRYOxR8QhUBCNe6GdEfy9BvFDIFtUvEkocvSvnrYt9lRm6FR1z0eQn0QSMenrgrDIJRMgUf9zsKQ==
   dependencies:
-    nan "^2.14.0"
-    node-pre-gyp "^0.11.0"
-    readable-stream "^2.3.5"
-    rimraf "^2.6.1"
+    node-addon-api "^3.1.0"
+    node-gyp-build "^4.2.1"
+    readable-stream "^3.6.0"
 
 make-dir@^1.0.0, make-dir@^1.1.0:
   version "1.3.0"
@@ -4943,27 +4924,12 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
   integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 minizlib@^2.0.0, minizlib@^2.1.1:
   version "2.1.2"
@@ -5013,7 +4979,7 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -5069,7 +5035,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
+ms@^2.0.0, ms@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -5088,7 +5054,7 @@ mv@^2.1.1:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.12.1, nan@^2.14.0:
+nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -5115,15 +5081,6 @@ ncp@~2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-needle@^2.2.1:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.8.0.tgz#1c8ef9c1a2c29dcc1e83d73809d7bc681c80a048"
-  integrity sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -5144,6 +5101,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
 node-emoji@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
@@ -5155,6 +5117,11 @@ node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-gyp-build@^4.2.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp@^7.1.0, node-gyp@^7.1.2:
   version "7.1.2"
@@ -5200,30 +5167,6 @@ node-libs-browser@^2.2.1:
     url "^0.11.0"
     util "^0.11.0"
     vm-browserify "^1.0.1"
-
-node-pre-gyp@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
-  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -5285,7 +5228,7 @@ npm-audit-report@^2.1.5:
   dependencies:
     chalk "^4.0.0"
 
-npm-bundled@^1.0.1, npm-bundled@^1.1.1:
+npm-bundled@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
   integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
@@ -5312,15 +5255,6 @@ npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-pack
     hosted-git-info "^4.0.1"
     semver "^7.3.4"
     validate-npm-package-name "^3.0.0"
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
 
 npm-packlist@^2.1.4:
   version "2.2.2"
@@ -5447,7 +5381,7 @@ npm@^7.0.0:
     which "^2.0.2"
     write-file-atomic "^3.0.3"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5566,7 +5500,7 @@ os-tmpdir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.3, osenv@^0.1.4:
+osenv@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -5869,6 +5803,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+peek-readable@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.4.tgz#f5c3b41a4eeb63a1322c4131f0b5bac7105b892e"
+  integrity sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg==
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -6128,7 +6067,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -6208,6 +6147,13 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stre
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
+  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
+  dependencies:
+    readable-stream "^3.6.0"
 
 readdir-scoped-modules@^1.1.0:
   version "1.1.0"
@@ -6413,7 +6359,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -6480,15 +6426,10 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -7061,6 +7002,14 @@ strip-outer@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+strtok3@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.1.3.tgz#488fe8ca91664cf93432c94752ba9e5c785bd9dd"
+  integrity sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    peek-readable "^3.1.4"
+
 subarg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
@@ -7143,23 +7092,10 @@ tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4:
-  version "4.4.15"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.15.tgz#3caced4f39ebd46ddda4d6203d48493a919697f8"
-  integrity sha512-ItbufpujXkry7bHH9NpQyTXPbJ72iTlXgkBAYsAjDXk3Ds8t/3NfO5P4xZGy7u+sYuQUbimgzswX4uQIEeNVOA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
 tar@^6.0.2, tar@^6.1.0, tar@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.2.tgz#1f045a90a6eb23557a603595f41a16c57d47adc6"
-  integrity sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.3.tgz#e44b97ee7d6cc7a4c574e8b01174614538291825"
+  integrity sha512-3rUqwucgVZXTeyJyL2jqtUau8/8r54SioM1xj3AmTX3HnWQdj2AydfJ2qYYayPyIIznSplcvU9mhBb7dR2XF3w==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -7304,6 +7240,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+token-types@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-3.1.0.tgz#df3902b514ba7573d8c6a2c0a6f69d1ac6a6f544"
+  integrity sha512-WhoeIW7UTn7NC7L0t/4x3vU/YYSS1oeUxYgiGXQLd82Kaf1qtlxOex3ETY0+o2QuRgAdyursMlUhQBKDCfMUkQ==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    ieee754 "^1.2.1"
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -7360,7 +7304,7 @@ tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.2.0:
+tslib@^2.0.0, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
@@ -7897,7 +7841,7 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Also:

- Bump bindl to v2, as this allows us to install the dependencies and
  develop on Windows natively.
- Add Windows to the matrix of operating systems to test in CI. This way
  we can assure the extension is working on Windows.
- Adjust test executor so it allows setting different versions of VS
  Code to test using an environment variable VSCODE_TEST_VERSION.
- Add matrix of VS Code versions to test in CI, so we can assure that
  we are not breaking the extension for the oldest supported VS Code
  version (currently 1.38.1, which uses Node 10).
- Change the default version of Node in CI to 14, as it's the current
  LTS, and the current VS Code (1.58.2) also uses it internally, and
  also because this version does not matter, as the extension will be
  tested against old versions of VS Code including older Node versions.
- Add `--new-window` flag to test runner, to make sure we won't reuse
  any dirty window such as one with remote openened.
- Upgrade non-breaking development dependencies.
- Fix dependabot `@types/node` ignore rule.
- Fix indents of some JSON and YAML files.