### PR TITLE
feat: allow `${workspaceFolder}` in `shellcheck.customArgs`

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -65,7 +65,9 @@ function substitutePath(s: string, workspaceFolder?: string): string {
     );
   }
 
-  return s.replace(/\${workspaceRoot}/g, workspaceFolder || "");
+  return s
+    .replace(/\${workspaceRoot}/g, workspaceFolder || "")
+    .replace(/\${workspaceFolder}/g, workspaceFolder || "");
 }
 
 export default class ShellCheckProvider implements vscode.CodeActionProvider {
@@ -212,7 +214,9 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
       trigger: RunTrigger.from(section.get("run", RunTrigger.strings.onType)),
       executable: this.getExecutable(section.get("executablePath", "")),
       exclude: section.get("exclude", []),
-      customArgs: section.get("customArgs", []),
+      customArgs: section
+        .get("customArgs", [])
+        .map((arg) => substitutePath(arg)),
       ignorePatterns: section.get("ignorePatterns", {}),
       ignoreFileSchemes: new Set(
         section.get("ignoreFileSchemes", ["git", "gitfs"])


### PR DESCRIPTION
Allow users to use `"${workspaceFolder}"` in `shellcheck.customArgs` such as ([Hombrew/brew/.vscode/settings.json](https://github.com/Homebrew/brew/blob/09b7ab2c1de3ab32f385aac922b2cd644fdd7c79/.vscode/settings.json#L10-L15)):

```json
"shellcheck.customArgs": [
  "--shell=bash",
  "--enable=all",
  "--external-sources",
  "--source-path=${workspaceFolder}/Library"
]
```