### PR TITLE
Revert "feat: use workspace folder as working directory by default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ For example, you can place it at `shellcheck.sh` in the root of your workspace a
 ```jsonc
 // .vscode/settings.json
 {
-  "shellcheck.executablePath": "${workspaceFolder}/shellcheck.sh"
+  // use the shim as shellcheck executable
+  "shellcheck.executablePath": "${workspaceFolder}/shellcheck.sh",
+
+  // you may also need to turn this option on, so shellcheck in the container
+  // can access all the files in the workspace
+  "shellcheck.useWorkspaceRootAsCwd": true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
           "description": "Whether to use the workspace root directory as the current working directory when launching ShellCheck.",
           "type": "boolean",
           "scope": "resource",
-          "default": true
+          "default": false
         },
         "shellcheck.disableVersionCheck": {
           "description": "Whether to disable shellcheck binary version check, which prompt for updating when outdated version found.",


### PR DESCRIPTION
This reverts commit eb05cb870312cc612f04dbb3e8d819da8b940cc2, because I noticed that when the `.shellcheckrc` file is present in subfolders, it's not being taken into account anymore (while in the old way it works).

It's now documented that docker shim scenarios may want to turn this option on.