### PR TITLE
docs: replace "Excluding Checks" with "Configuring Shellcheck"

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ By default the linter will lint as you type. Alternatively, set `shellcheck.run`
 }
 ```
 
-### Configure ShellCheck
+### Configuring ShellCheck
 
 [ShellCheck] has a default set of checks, but it is also configurable using [RC files](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files). To configure your project, add a `.shellcheckrc` at the workspace root. If no `.shellcheckrc` is found in any of the parent directories, ShellCheck will look in `~/.shellcheckrc` followed by the `$XDG_CONFIG_HOME` (usually `~/.config/shellcheckrc`) on Unix, or `%APPDATA%/shellcheckrc` on Windows. Only the first file found will be used.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Here is an example `.shellcheckrc`:
 source-path=SCRIPTDIR
 source-path=/mnt/chroot
 
-# Since 0.9.0, values can be quoted with '' or "" to allow spaces
+# Since ShellCheck 0.9.0, values can be quoted with '' or "" to allow spaces
 source-path="My Documents/scripts"
 
 # Allow opening any 'source'd file, even if not specified as input

--- a/README.md
+++ b/README.md
@@ -107,14 +107,32 @@ By default the linter will lint as you type. Alternatively, set `shellcheck.run`
 }
 ```
 
-### Excluding Checks
+### Configure ShellCheck
 
-By default all [ShellCheck] checks are performed and reported on as necessary. To globally ignore certain checks in all files, you can use a `.shellcheckrc` at the workspace root. For example, to exclude [SC1017](https://github.com/koalaman/shellcheck/wiki/SC1017):
+[ShellCheck] has a default set of checks, but it is also configurable using [RC files](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files). To configure your project, add a `.shellcheckrc` at the workspace root. If no `.shellcheckrc` is found in any of the parent directories, ShellCheck will look in `~/.shellcheckrc` followed by the `$XDG_CONFIG_HOME` (usually `~/.config/shellcheckrc`) on Unix, or `%APPDATA%/shellcheckrc` on Windows. Only the first file found will be used.
+
+Here is an example `.shellcheckrc`:
 
 ```ini
-# .shellcheckrc
+# Look for 'source'd files relative to the checked script,
+# and also look for absolute paths in /mnt/chroot
+source-path=SCRIPTDIR
+source-path=/mnt/chroot
 
-disable=SC1017
+# Since 0.9.0, values can be quoted with '' or "" to allow spaces
+source-path="My Documents/scripts"
+
+# Allow opening any 'source'd file, even if not specified as input
+external-sources=true
+
+# Turn on warnings for unquoted variables with safe values
+enable=quote-safe-variables
+
+# Turn on warnings for unassigned uppercase variables
+enable=check-unassigned-uppercase
+
+# Allow [ ! -z foo ] instead of suggesting -n
+disable=SC2236
 ```
 
 As last resort, you can also add the _SC_ identifiers to `shellcheck.exclude` extension setting. For example, to exclude [SC1017](https://github.com/koalaman/shellcheck/wiki/SC1017):

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "posttest",
     "precompiled",
     "ralish",
+    "SCRIPTDIR",
     "shellcheck",
     "shellcheckrc",
     "shellname",


### PR DESCRIPTION
The "Excluding Checks" section was only explaining how to exclude a check within the workspace, but it's possible to configure much more than check exclusions, and it's also possible to configure outside the workspace as well.

This commit replace the "Excluding Checks" section for a more general "Configure Shellcheck" section. In this section, I copy-pasted blocks of text from the official documentation:
https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files

It explains how you can write the RC files, where you can create the files, and how they are resolved by Shellcheck.

Fixes #1824 